### PR TITLE
Set French at file loading, naming stuff for extra subs

### DIFF
--- a/sadx-russian-mod/ExtraSubs.cpp
+++ b/sadx-russian-mod/ExtraSubs.cpp
@@ -5,7 +5,6 @@
 
 
 FunctionHook<int, int, void*, int, void*> PlaySound_Hook(0x423D70);
-FunctionPointer(void, sub_40BC80, (), 0x40BC80);
 
 const char* Buffer[] = { NULL, NULL };
 const char* TextBuffer = NULL;
@@ -912,8 +911,8 @@ void InitExtraSubs()
 {
 	WriteJump((void*)0x425710, PlayVoice_ExtraSub);
 	PlaySound_Hook.Hook(PlaySound_ExtraSub);
-	WriteData((char*)0x40BC9A, (char)52); //меняю высоту текст-бокса для меню, чтобы влезало 2 строки нормально
-	WriteData((int*)0x40BCA1, 384); //меняю координату y для текст-бокса, чтобы для обоих методов вывода их размеры и расположение совпадали
+	WriteData((char*)0x40BC9A, (char)52);	// меняю высоту текст-бокса для меню, чтобы влезало 2 строки нормально
+	WriteData((int*)0x40BCA1, 384);			// меняю координату y для текст-бокса, чтобы для обоих методов вывода их размеры и расположение совпадали
 }
 
 
@@ -921,8 +920,8 @@ void InitExtraSubs()
 
 void DisplaySubtitleForOneFrame()
 {
-	sub_40BC80();
-	DoSomethingRelatedToText_(TextBuffer);
+	DialogJimakuInit();
+	DialogJimakuPut(TextBuffer);
 	SubtitleDisplayFrameCount++;
 }
 
@@ -935,26 +934,26 @@ void ClearSubtitle()
 
 void DisplayEggCannonSubtitles()
 {
-	sub_40BC80();
+	DialogJimakuInit();
 	if (EggCannonFrameCount <= 180)
 	{
-		DoSomethingRelatedToText_(SkyChase1EggCannon[0]);
+		DialogJimakuPut(SkyChase1EggCannon[0]);
 	}
 	else if (EggCannonFrameCount <= 270)
 	{
-		DoSomethingRelatedToText_(SkyChase1EggCannon[1]);
+		DialogJimakuPut(SkyChase1EggCannon[1]);
 	}
 	else if (EggCannonFrameCount > 360 && EggCannonFrameCount <= 480)
 	{
-		DoSomethingRelatedToText_(SkyChase1EggCannon[2]);
+		DialogJimakuPut(SkyChase1EggCannon[2]);
 	}
 	else if (EggCannonFrameCount > 660 && EggCannonFrameCount <= 780)
 	{
-		DoSomethingRelatedToText_(SkyChase1EggCannon[3]);
+		DialogJimakuPut(SkyChase1EggCannon[3]);
 	}
 	else if (EggCannonFrameCount > 780)
 	{
-		DoSomethingRelatedToText_(SkyChase1EggCannon[4]);
+		DialogJimakuPut(SkyChase1EggCannon[4]);
 	}
 	EggCannonFrameCount++;
 }

--- a/sadx-russian-mod/LanguageSetting.cpp
+++ b/sadx-russian-mod/LanguageSetting.cpp
@@ -5,6 +5,7 @@
 FunctionPointer(char, AvaSetTextSettei, (char language), 0x5068C0);
 FunctionPointer(char, AvaSetVoiceSettei, (char language), 0x506870);
 FunctionPointer(int, AvaSaveFiles, (), 0x5065E0);
+FunctionPointer(void, dsVMSLoadGame, (), 0x421DE0);
 
 
 // Вся эта дичь буквально ради того, чтобы скипнуть за ненадобностью диалог с выбором языка текста и форсировать французский язык текста, на месте которого мы выводим русский
@@ -40,8 +41,14 @@ void SetLanguagesOnNewSave()
 	WriteCall((void*)0x503787, SetLanguagesAndSaveFile);
 }
 
+void AvaLoadFiles_SetFrench()
+{
+	dsVMSLoadGame();
+	AvaSetTextSettei(Languages_French);
+}
 
-// Это делается ради того, чтобы сразу при запуске игры стоял французский, независимо от настроек мод-менеджера
+
+// Это делается ради того, чтобы сразу при запуске игры стоял французский, независимо от настроек мод-менеджера (идёт в OnFrame, потому что установка языка в Init не делает ничего)
 
 bool FrenchInit = false;
 void SetFrenchTextAtLaunch() 
@@ -57,4 +64,5 @@ void InitLanguageSetting()
 {
 	SkipTextLanguageSelectionAndSetFrench();
 	SetLanguagesOnNewSave();
+	WriteJump((void*)0x506600, AvaLoadFiles_SetFrench);
 }


### PR DESCRIPTION
Выставляю французский при загрузке любого сейва, независимо от того, какой язык на нём стоял, чтобы избежать бага с отображением текста, когда язык текста игры выставлен на японский или английский (из-за японской кодировки).
И переименовал функции, вызываемые для экстрасабов, в соответствии с символами с Xbox 360-версии (вместо всяких sub_чё-то-там).